### PR TITLE
Fixed author list on minimal theme

### DIFF
--- a/src/zenfolio/themes/minimal/theme.py
+++ b/src/zenfolio/themes/minimal/theme.py
@@ -178,7 +178,7 @@ body {
 
     PUBLICATION_ITEM_TEMPLATE = """<article class="card publication-card reveal-on-scroll">
     <h3 class="card-title">{{ item.title }}</h3>
-    <p class="card-meta pub-authors">{{ item.authors | safe }}</p>
+    <p class="card-meta pub-authors">{{ item.authors | join(', ') | safe }}</p>
     <p class="card-meta pub-venue">{{ item.venue }}, {{ item.year }}</p>
     <div class="card-links">
     {% if item.links %}


### PR DESCRIPTION
Author list was appearing as:

`['name1', 'name2', ... ]`

This small fix should help the list to be properly rendered , i.e.

`name1, name2, ... `

Thanks a lot for creating this very useful tool :)